### PR TITLE
Support PDF page images when text extraction fails

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ openai
 python-dotenv
 langchain_community
 PyPDF2
+pdf2image


### PR DESCRIPTION
## Summary
- expand `read_sample` to return image data for PDF pages when text can't be extracted
- handle multi-page results when reading samples
- add `pdf2image` to dependencies

## Testing
- `python -m py_compile app.py excel_format_analyzer.py`

------
https://chatgpt.com/codex/tasks/task_e_6874e2b42b948322a972a93b33ed1483